### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/bun-ci.yml
+++ b/.github/workflows/bun-ci.yml
@@ -1,5 +1,8 @@
 name: Bun CI
 
+permissions:
+  contents: read
+
 concurrency:
   group: bun-ci-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/tranhoangtu-it/OpenCut/security/code-scanning/1](https://github.com/tranhoangtu-it/OpenCut/security/code-scanning/1)

To fix this issue, we will add an explicit `permissions` key to the root of the workflow file `.github/workflows/bun-ci.yml`. This will apply the permissions settings uniformly across all jobs in the workflow. Since the workflow only appears to require read access to repository contents to perform its tasks, we will set `contents: read` as the permission. This adheres to the principle of least privilege and avoids granting unnecessary write permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
